### PR TITLE
Add `cache_on_errors` plugin option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,20 @@ To set the cache expiry time to one hour you would add this to your Datasette `m
 }
 ```
 
+By default, `cache_on_errors` is `true`, which means that caching is applied to all responses despite its status code. 
+
+You can set it to `false` if you prefer to skip plugin's caching logic on responses where HTTP status code >= 400.
+
+```json
+{
+    "plugins": {
+        "datasette-hashed-urls": {
+            "cache_on_errors": false
+        }
+    }
+}
+```
+
 ## History
 
 This functionality used to ship as part of Datasette itself, as a feature called [Hashed URL mode](https://docs.datasette.io/en/0.60.2/performance.html#hashed-url-mode).

--- a/datasette_hashed_urls/__init__.py
+++ b/datasette_hashed_urls/__init__.py
@@ -110,10 +110,14 @@ async def handle_hashed_urls(datasette, app, scope, receive, send):
     else:
         plugin_config = datasette.plugin_config("datasette-hashed-urls") or {}
         max_age = plugin_config.get("max_age", 31536000)
+        cache_on_errors = plugin_config.get("cache_on_errors", True)
 
         # Hash is correct, add a far-future cache header
         async def wrapped_send(event):
-            if event["type"] == "http.response.start":
+            if (
+                event["type"] == "http.response.start" 
+                and (cache_on_errors or event["status"] < 400)
+            ):
                 original_headers = [
                     pair
                     for pair in event.get("headers")


### PR DESCRIPTION
Add `cache_on_errors` plugin option to prevent caching on HTTP status >= 400. Relates to https://github.com/simonw/datasette-hashed-urls/issues/17